### PR TITLE
Add option to stop after download in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ $ torrentp --link 'test.torrent'
 | --download_speed | Download speed with a specific number (kB/s). Default: 0, means unlimited speed | ```int``` |
 | --upload_speed | Upload speed with a specific number (kB/s). Default: 0, means unlimited speed | ```int``` |
 | --save_path | Path to save the file, default: '.' | ```str``` |
+| --stop_after_download | Stop the download immediately after completion without seeding | ```flag``` |
 | --help |Show this message and exit |  |
 
 Example with all commands:
 ```sh
-$ torrentp --link 'magnet:...' --download_speed 100 --upload_speed 50 --save_path '.'
+$ torrentp --link 'magnet:...' --download_speed 100 --upload_speed 50 --save_path '.' --stop_after_download
 ```
 
 ### To do list

--- a/torrentp/cli.py
+++ b/torrentp/cli.py
@@ -21,9 +21,10 @@ async def handle_input(torrent_file):
 @click.option('--download_speed',  default=0, help='Download speed with a specific number (kB/s). Default: 0, means unlimited speed', type=int)
 @click.option('--upload_speed',  default=0, help='Upload speed with a specific number (kB/s). Default: 0, means unlimited speed', type=int)
 @click.option('--save_path',  default='.', help="Path to save the file, default: '.' ", type=str)
-async def run_cli(link, download_speed, upload_speed, save_path):
+@click.option('--stop_after_download', is_flag=True, help="Stop the download immediately after completion without seeding")
+async def run_cli(link, download_speed, upload_speed, save_path, stop_after_download):
     try:
-        torrent_file = TorrentDownloader(link, save_path)
+        torrent_file = TorrentDownloader(link, save_path, stop_after_download=stop_after_download)
         
         input_task = asyncio.create_task(handle_input(torrent_file))
         download_task = asyncio.create_task(torrent_file.start_download(download_speed=download_speed, upload_speed=upload_speed))

--- a/torrentp/downloader.py
+++ b/torrentp/downloader.py
@@ -4,7 +4,7 @@ import math
 import time
 
 class Downloader:
-    def __init__(self, session, torrent_info, save_path, libtorrent, is_magnet):
+    def __init__(self, session, torrent_info, save_path, libtorrent, is_magnet, stop_after_download=False):
         self._session = session
         self._torrent_info = torrent_info
         self._save_path = save_path
@@ -16,6 +16,7 @@ class Downloader:
         self._add_torrent_params = None
         self._is_magnet = is_magnet
         self._paused = False
+        self._stop_after_download = stop_after_download
 
     def status(self):
         if not self._is_magnet:
@@ -44,7 +45,11 @@ class Downloader:
                 sys.stdout.flush()
 
             await asyncio.sleep(1)
-        print('\033[92m' +  "\nDownloaded successfully." + '\033[0m')
+        
+        if self._stop_after_download:
+            self.stop()
+        else:
+            print('\033[92m' +  "\nDownloaded successfully." + '\033[0m')
 
     def _get_status_progress(self, s):
         _percentage = s.progress * 100

--- a/torrentp/torrent_downloader.py
+++ b/torrentp/torrent_downloader.py
@@ -5,7 +5,7 @@ import libtorrent as lt
 
 
 class TorrentDownloader:
-    def __init__(self, file_path, save_path, port=6881):
+    def __init__(self, file_path, save_path, port=6881, stop_after_download=False):
         self._file_path = file_path
         self._save_path = save_path
         self._port = port  # Default port is 6881
@@ -15,6 +15,7 @@ class TorrentDownloader:
         self._file = None
         self._add_torrent_params = None
         self._session = Session(self._lt, port=self._port)  # Pass port to Session
+        self._stop_after_download = stop_after_download
 
     async def start_download(self, download_speed=0, upload_speed=0):
         if self._file_path.startswith('magnet:'):
@@ -22,14 +23,14 @@ class TorrentDownloader:
             self._add_torrent_params.save_path = self._save_path
             self._downloader = Downloader(
                 session=self._session(), torrent_info=self._add_torrent_params, 
-                save_path=self._save_path, libtorrent=lt, is_magnet=True
+                save_path=self._save_path, libtorrent=lt, is_magnet=True, stop_after_download=self._stop_after_download
             )
 
         else:
             self._torrent_info = TorrentInfo(self._file_path, self._lt)
             self._downloader = Downloader(
                 session=self._session(), torrent_info=self._torrent_info(), 
-                save_path=self._save_path, libtorrent=None, is_magnet=False
+                save_path=self._save_path, libtorrent=None, is_magnet=False, stop_after_download=self._stop_after_download
             )
 
         self._session.set_download_limit(download_speed)


### PR DESCRIPTION
Fixes #26

Add an option to immediately stop downloading a torrent without seeding when the download finishes.

* **CLI Changes**
  - Add a new option `--stop_after_download` to the `run_cli` function in `torrentp/cli.py`.
  - Pass the `stop_after_download` option to the `TorrentDownloader` class.

* **Downloader Class Changes**
  - Add a new parameter `stop_after_download` to the `Downloader` class constructor in `torrentp/downloader.py`.
  - Modify the `download` method to check for the `stop_after_download` flag and stop the download immediately after completion without seeding.

* **TorrentDownloader Class Changes**
  - Add a new parameter `stop_after_download` to the `start_download` method in `torrentp/torrent_downloader.py`.
  - Pass the `stop_after_download` parameter to the `Downloader` class.

* **Documentation Update**
  - Update the CLI usage section in `README.md` to include the new `--stop_after_download` option.

