### PR TITLE
Add progress tracking to TorrentDownloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ torrent_file.resume_download()
 
 # Stopping the download
 torrent_file.stop_download()
+
+# Getting the download progress
+progress = torrent_file.get_progress()
+print(f"Download progress: {progress}%")
 ```
 Or download with .torrent file:
 ```python
@@ -56,6 +60,10 @@ torrent_file.resume_download()
 
 # Stopping the download
 torrent_file.stop_download()
+
+# Getting the download progress
+progress = torrent_file.get_progress()
+print(f"Download progress: {progress}%")
 ```
 #### How can I use a custom port?
 

--- a/torrentp/downloader.py
+++ b/torrentp/downloader.py
@@ -17,6 +17,7 @@ class Downloader:
         self._is_magnet = is_magnet
         self._paused = False
         self._stop_after_download = stop_after_download
+        self._progress = 0  # Pb7d0
 
     def status(self):
         if not self._is_magnet:
@@ -53,6 +54,7 @@ class Downloader:
 
     def _get_status_progress(self, s):
         _percentage = s.progress * 100
+        self._progress = _percentage  # Pb7d0
         _download_speed = s.download_rate / 1000
         _upload_speed = s.upload_rate / 1000
 
@@ -103,6 +105,9 @@ class Downloader:
 
     def is_paused(self):
         return self._paused
+
+    def get_progress(self):  # P00ff
+        return self._progress  # P00ff
 
     def __str__(self):
         pass

--- a/torrentp/torrent_downloader.py
+++ b/torrentp/torrent_downloader.py
@@ -51,6 +51,11 @@ class TorrentDownloader:
         if self._downloader:
             self._downloader.stop()
 
+    def get_progress(self):
+        if self._downloader:
+            return self._downloader.get_progress()
+        return 0
+
     def __str__(self):
         pass
 


### PR DESCRIPTION
Fixes #10

Add functionality to track and access the progress of downloading a torrent via an API request.

* **torrentp/downloader.py**
  - Add a `_progress` instance variable to store the progress percentage.
  - Update the `_get_status_progress` method to store the progress percentage in the `_progress` variable.
  - Add a `get_progress` method to return the current progress percentage.

* **torrentp/torrent_downloader.py**
  - Add a `get_progress` method to call the `get_progress` method of the `Downloader` class.

* **README.md**
  - Add instructions on how to access the download progress via the new API method.

