### PR TITLE
Update python code to download magnet link with nested event loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,16 @@ Download with magnet link:
 ```python
 import asyncio
 from torrentp import TorrentDownloader
+import nest_asyncio
+
+# Apply nest_asyncio to allow nested event loops
+nest_asyncio.apply()
+
 torrent_file = TorrentDownloader("magnet:...", '.')
-# Start the download process
-asyncio.run(torrent_file.start_download()) # start_download() is a asynchronous method 
+
+# Start the download process using the existing event loop
+loop = asyncio.get_event_loop()
+loop.run_until_complete(torrent_file.start_download())  # start_download() is a asynchronous method 
 
 # Pausing the download
 torrent_file.pause_download()


### PR DESCRIPTION
If we download the torrent in online servers it throws 'RuntimeError: asyncio.run() cannot be called from a running event loop'. Fixed it by using nest_asyncio module